### PR TITLE
fix: updated text in terminal cast to match documentation

### DIFF
--- a/casts/build/screencast.config.js
+++ b/casts/build/screencast.config.js
@@ -1,13 +1,14 @@
 module.exports = {
   cast: `
     printf '\\033[0;32m%s\\033[0m' "λ "
-    echo "patternplate build --base='/' --out='docs'" | pv -qL $[10+(-2 + RANDOM%5)]
+    echo "yarn patternplate build --out=docs/patterns --base=/patterns/" | pv -qL $[10+(-2 + RANDOM%5)]
     ../../node_modules/.bin/patternplate build --base="/" --out="docs"
 
     printf '\\033[0;32m%s\\033[0m' "λ "
     echo ""
   `,
   transform(svg) {
+    // TODO: do not hardcode this directory
     return svg.split('/Users/marneb/Projects/pp/media/casts/build/docs').join('docs/');
   },
   term: {


### PR DESCRIPTION
I updated the text in the location you pointed me too, but I could not get the project to produce a new animated gif asset. I went down a rabbit hole of installing pdf2svg and inkscape to try to get this to work, but got stuck when inkscape started throwing errors that it was trying to use a deprecated Mac OS function.